### PR TITLE
add wiki-tables

### DIFF
--- a/mock_server/text.py
+++ b/mock_server/text.py
@@ -60,4 +60,4 @@ def markdown(content, protocol="", ref_id=""):
         new_content.append(
             param_text % (param_data + ("\n".join(description), )))
 
-    return markdown2.markdown("\n".join(new_content))
+    return markdown2.markdown("\n".join(new_content), extras=["wiki-tables"])


### PR DESCRIPTION
Google Code Wiki table syntax support. https://github.com/trentm/python-markdown2/wiki/wiki-tables
