### PR TITLE
use bcrypt instead of py-bcrypt

### DIFF
--- a/mock_server/handlers.py
+++ b/mock_server/handlers.py
@@ -193,7 +193,7 @@ class MainHandler(BaseHandler, HttpAuthBasicMixin):
         # get request data
         self.format = self._get_format(format)
         method = self.request.method
-        self.status_code = int(self.get_argument("__statusCode", 200))
+        self.status_code = None  # we will calculate this from available files
 
         # upstream server
         upstream_server = self.api_data.get_upstream_server(

--- a/mock_server/handlers.py
+++ b/mock_server/handlers.py
@@ -136,9 +136,14 @@ class MainHandler(BaseHandler, HttpAuthBasicMixin):
 
     @tornado.web.asynchronous
     def options(self, path, format=DEFAULT_FORMAT):
-        self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
-        self.set_header("Access-Control-Allow-Credentials", "true")
         self.set_header("Access-Control-Max-Age", 21600)
+        self.set_header("Access-Control-Allow-Credentials", "true")
+
+        # some apps need to know the origin
+        if "Origin" in self.request.headers:
+            self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+        else:
+            self.set_header("Access-Control-Allow-Origin", "*")
 
         if "Access-Control-Request-Headers" in self.request.headers:
             self.set_header(
@@ -160,6 +165,14 @@ class MainHandler(BaseHandler, HttpAuthBasicMixin):
     def _handle_request_on_upstream(self):
         provider = rest.UpstreamServerProvider(
             self.api_data.upstream_server)
+
+        self.set_header("Access-Control-Allow-Credentials", "true")
+
+        # some apps need to know the origin
+        if "Origin" in self.request.headers:
+            self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+        else:
+            self.set_header("Access-Control-Allow-Origin", "*")
 
         provider({
             "uri": self.request.uri,
@@ -207,10 +220,14 @@ class MainHandler(BaseHandler, HttpAuthBasicMixin):
             content_type = SUPPORTED_FORMATS[self.format][0]
             response.headers.append(
                 ("Content-Type", "%s; charset=utf-8" % content_type))
-        response.headers.append(
-            ("Access-Control-Allow-Origin", self.request.headers["Origin"]))
-        response.headers.append(
-            ("Access-Control-Allow-Credentials", "true"))
+
+        self.set_header("Access-Control-Allow-Credentials", "true")
+
+        # some apps need to know the origin
+        if "Origin" in self.request.headers:
+            self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+        else:
+            self.set_header("Access-Control-Allow-Origin", "*")
 
         # log request
         self.log_request(response)
@@ -249,8 +266,14 @@ class RPCHandler(BaseHandler):
     def post(self):
         # log request
         self.log_request()
-        self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+
         self.set_header("Access-Control-Allow-Credentials", "true")
+
+        # some apps need to know the origin
+        if "Origin" in self.request.headers:
+            self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+        else:
+            self.set_header("Access-Control-Allow-Origin", "*")
 
         if "Content-Length" not in self.request.headers and \
                 self.request.headers.get(

--- a/mock_server/handlers.py
+++ b/mock_server/handlers.py
@@ -136,7 +136,8 @@ class MainHandler(BaseHandler, HttpAuthBasicMixin):
 
     @tornado.web.asynchronous
     def options(self, path, format=DEFAULT_FORMAT):
-        self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+        self.set_header("Access-Control-Allow-Credentials", "true")
         self.set_header("Access-Control-Max-Age", 21600)
 
         if "Access-Control-Request-Headers" in self.request.headers:
@@ -207,7 +208,9 @@ class MainHandler(BaseHandler, HttpAuthBasicMixin):
             response.headers.append(
                 ("Content-Type", "%s; charset=utf-8" % content_type))
         response.headers.append(
-            ("Access-Control-Allow-Origin", "*"))
+            ("Access-Control-Allow-Origin", self.request.headers["Origin"]))
+        response.headers.append(
+            ("Access-Control-Allow-Credentials", "true"))
 
         # log request
         self.log_request(response)
@@ -246,7 +249,8 @@ class RPCHandler(BaseHandler):
     def post(self):
         # log request
         self.log_request()
-        self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+        self.set_header("Access-Control-Allow-Credentials", "true")
 
         if "Content-Length" not in self.request.headers and \
                 self.request.headers.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tornado==4.3
 markdown2 >= 2.1.0
-py-bcrypt >= 0.3
+bcrypt >= 3.1.4
 futures >= 2.1.3
 jsonrpclib==0.1.7
 six==1.10.0


### PR DESCRIPTION
py-bcrypt 0.4 has collisions with Flask-Bcrypt 0.7.1

Specifically, we saw this error with Flask-Bcrypt after started using mock-server (and therefore started using py-bcrypt):

`  File "/home/ofir/Workspace/dlpc-hmi/venv/local/lib/python2.7/site-packages/flask_bcrypt.py", line 193, in check_password_hash
    return safe_str_cmp(bcrypt.hashpw(password, pw_hash), pw_hash)
ValueError: Invalid salt
`